### PR TITLE
docs: update Go version from 1.23 to 1.24

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -114,7 +114,7 @@ make docker-up-prod
 | Aspect | Development | Production |
 |--------|-------------|------------|
 | **Dockerfile Stage** | `development` | `production` |
-| **Base Image** | golang:1.21-alpine | alpine:latest |
+| **Base Image** | golang:1.24-alpine | alpine:latest |
 | **Code Location** | Volume mounted | Baked in image |
 | **Hot-Reload** | ✅ Yes (Air) | ❌ No |
 | **Image Size** | ~800MB | ~15MB |
@@ -365,7 +365,7 @@ docker-compose up
 
 This project uses **Air v1.52.3** (pinned version) instead of `@latest` because:
 - Air v1.63.0 has a bug requiring non-existent Go 1.25
-- v1.52.3 is stable and fully compatible with Go 1.23
+- v1.52.3 is stable and fully compatible with Go 1.24
 - All hot-reload features work perfectly
 
 When Air fixes the issue, you can update to `@latest` in the Dockerfile.

--- a/docs/DOCS_SETUP.md
+++ b/docs/DOCS_SETUP.md
@@ -145,7 +145,7 @@ Use admonitions for tips, warnings, notes:
     Change JWT_SECRET before production!
 
 !!! note
-    This feature requires Go 1.23+
+    This feature requires Go 1.24+
 
 !!! danger
     This operation is irreversible!

--- a/docs/MIGRATIONS_GUIDE.md
+++ b/docs/MIGRATIONS_GUIDE.md
@@ -175,7 +175,7 @@ Add migration step to your CI/CD or deployment process.
 
 ```dockerfile
 # Add to Dockerfile
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24-alpine AS builder
 RUN apk add --no-cache git
 RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 ```

--- a/docs/PROJECT_SUMMARY.md
+++ b/docs/PROJECT_SUMMARY.md
@@ -114,7 +114,7 @@ go-rest-api-boilerplate/
 
 ### CI/CD
 - **GitHub Actions** workflow
-- **Multi-version testing** (Go 1.20, 1.21)
+- **Multi-version testing** (Go 1.23, 1.24)
 - **Linting** with golangci-lint
 - **Automated tests** on push/PR
 - **Coverage reporting**
@@ -130,7 +130,7 @@ go-rest-api-boilerplate/
 
 | Component | Technology | Purpose |
 |-----------|-----------|---------|
-| Language | Go 1.21 | Performance, simplicity, type safety |
+| Language | Go 1.24 | Performance, simplicity, type safety |
 | Web Framework | Gin | Fast HTTP router, middleware support |
 | ORM | GORM | Database abstraction, migrations |
 | Database | PostgreSQL 15 | Reliable, feature-rich RDBMS |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,7 +12,7 @@ Complete setup instructions for the Go REST API Boilerplate (GRAB).
 - **Git** ([Download](https://git-scm.com/downloads))
 
 ### Required for Manual Setup
-- **Go 1.23+** ([Download](https://golang.org/dl/))
+- **Go 1.24+** ([Download](https://golang.org/dl/))
 - **PostgreSQL 15+** ([Download](https://www.postgresql.org/download/))
 - **Git** ([Download](https://git-scm.com/downloads))
 - **Make** (usually pre-installed on Unix systems)
@@ -139,7 +139,7 @@ make migrate-down
 ### Container Details
 
 **Development Container:**
-- Base: `golang:1.23-bookworm` (Debian for SQLite compatibility)
+- Base: `golang:1.24-bookworm` (Debian for SQLite compatibility)
 - Includes: `air`, `swag`, `golangci-lint`, `migrate`
 - Hot-reload: Changes detected in ~2 seconds
 - Volume: Code synced from host to container
@@ -171,13 +171,13 @@ For developers who prefer to run the application directly on their host machine.
 
 ### Step 1: Install Go
 
-Ensure you have **Go 1.23 or later** installed:
+Ensure you have **Go 1.24 or later** installed:
 
 ```bash
 # Check Go version
 go version
 
-# Should output: go version go1.23.x ...
+# Should output: go version go1.24.x ...
 ```
 
 If Go is not installed, download it from [https://golang.org/dl/](https://golang.org/dl/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 <p>
 <img src="https://img.shields.io/badge/version-1.1.0-blue.svg" alt="Version">
 <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License">
-<img src="https://img.shields.io/badge/Go-1.23+-00ADD8?logo=go" alt="Go Version">
+<img src="https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go" alt="Go Version">
 </p>
 
 <p>


### PR DESCRIPTION
## 📝 Summary

Updates all documentation references from Go version 1.23 to Go version 1.24 to align with the boilerplate project's latest requirements.

## 🔄 Changes Made

### Core Updates
- **SETUP.md**: Updated Go requirement from 1.23+ to 1.24+
- **index.md**: Updated version badge to reflect Go 1.24+  
- **PROJECT_SUMMARY.md**: Updated technical stack table to Go 1.24
- **DOCKER.md**: Updated Docker base images and compatibility notes
- **MIGRATIONS_GUIDE.md**: Updated Dockerfile examples
- **DOCS_SETUP.md**: Updated feature requirements

### Specific Changes
- Docker base images: `golang:1.23-bookworm` → `golang:1.24-bookworm`
- Docker production: `golang:1.21-alpine` → `golang:1.24-alpine`
- CI/CD testing: "Go 1.20, 1.21" → "Go 1.23, 1.24"
- Air compatibility notes updated for Go 1.24

## ✅ Verification

- [x] All markdown files updated consistently
- [x] Documentation site rebuilt successfully
- [x] No broken links or references
- [x] Version references are consistent across all files

## 📚 Impact

This ensures the documentation accurately reflects the current Go version requirements for the boilerplate project, providing users with the correct setup instructions and version compatibility information.

## 🔗 Related

Part of keeping the documentation synchronized with the main boilerplate project's Go version upgrades.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs and examples to Go 1.24 across requirements, badges, CI matrix, and Docker base images.
> 
> - **Docs**:
>   - Update Go requirement to `1.24+` in `docs/SETUP.md`, `docs/DOCS_SETUP.md`, and `docs/index.md` badge.
>   - Revise `docs/PROJECT_SUMMARY.md`:
>     - Language: `Go 1.21` → `Go 1.24`
>     - CI matrix: `Go 1.20, 1.21` → `Go 1.23, 1.24`
> - **Docker**:
>   - Change development/guide references:
>     - `golang:1.23-bookworm` → `golang:1.24-bookworm` (`docs/SETUP.md`)
>     - `golang:1.21-alpine` → `golang:1.24-alpine` (`docs/MIGRATIONS_GUIDE.md`, `docs/DOCKER.md` table)
>   - Update Air compatibility note to Go `1.24` (`docs/DOCKER.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a72122d7698509f74bed0e2b2ff16ab2ffda0c86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->